### PR TITLE
v0.5.6 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ---
 
+## [0.5.6] - 2025-08-15
+
+### Added
+- Added ability to copy products in the admin panel.
+- Added EULA detection: when a server requires EULA acceptance after reinstallation, a modal with an Accept EULA button is displayed.
+- Added PteroCA Addon for Pterodactyl version check on the admin dashboard.
+- Added `pteroca:sync-servers` command to automatically remove servers no longer present in Pterodactyl.
+
+### Changed
+- Updated README.md file.
+- Slight upgrade to the update command with improved local change protection, better repository fetching, enhanced scenario handling, and clearer error messages.
+
+### Fixed
+- Fixed grid layout issue in the My Servers section.
+
+---
+
 ## [0.5.5] - 2025-07-27
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pteroca/panel",
     "description": "PteroCA.com is a free, open-source client area and management panel designed specifically for Pterodactyl server users and hosting providers. The platform simplifies and automates server management with a user-friendly interface and robust billing features.",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "type": "project",
     "license": "MIT",
     "minimum-stability": "stable",

--- a/src/Core/Resources/config/services.yaml
+++ b/src/Core/Resources/config/services.yaml
@@ -1,5 +1,5 @@
 parameters:
-  version: '0.5.5'
+  version: '0.5.6'
   categories_base_path: '/uploads/categories'
   categories_directory: 'public/uploads/categories'
   products_base_path: '/uploads/products'

--- a/themes/default/template.json
+++ b/themes/default/template.json
@@ -5,7 +5,7 @@
     "author": "PteroCA.com",
     "version": "1.1.0",
     "license": "MIT",
-    "pterocaVersion": "0.5.5",
+    "pterocaVersion": "0.5.6",
     "phpVersion": ">=8.2",
     "options": {
       "supportDarkMode": true,


### PR DESCRIPTION
## [0.5.6] - 2025-08-15

### Added
- Added ability to copy products in the admin panel.
- Added EULA detection: when a server requires EULA acceptance after reinstallation, a modal with an Accept EULA button is displayed.
- Added PteroCA Addon for Pterodactyl version check on the admin dashboard.
- Added `pteroca:sync-servers` command to automatically remove servers no longer present in Pterodactyl.

### Changed
- Updated README.md file.
- Slight upgrade to the update command with improved local change protection, better repository fetching, enhanced scenario handling, and clearer error messages.

### Fixed
- Fixed grid layout issue in the My Servers section.
