### PR TITLE
Update Buttons in Server Suspended, Server Renewed and Server Purchased E-Mails

### DIFF
--- a/src/Core/DTO/Email/EmailContextDTO.php
+++ b/src/Core/DTO/Email/EmailContextDTO.php
@@ -11,6 +11,7 @@ readonly class EmailContextDTO
         private string $currency,
         private array $serverData,
         private array $panelData,
+        private string $siteUrl,
     ) {}
 
     public function getUser(): UserInterface
@@ -33,6 +34,11 @@ readonly class EmailContextDTO
         return $this->panelData;
     }
 
+    public function getSiteUrl(): string
+    {
+        return $this->siteUrl;
+    }
+
     public function toArray(): array
     {
         return [
@@ -40,6 +46,7 @@ readonly class EmailContextDTO
             'currency' => $this->currency,
             'server' => $this->serverData,
             'panel' => $this->panelData,
+            'siteUrl' => $this->siteUrl,
         ];
     }
 }

--- a/src/Core/DTO/Email/PurchaseEmailContextDTO.php
+++ b/src/Core/DTO/Email/PurchaseEmailContextDTO.php
@@ -12,10 +12,11 @@ readonly class PurchaseEmailContextDTO extends EmailContextDTO
         string $currency,
         array $serverData,
         array $panelData,
+        string $siteUrl,
         private ProductInterface $product,
         private PriceCalculationDTO $priceCalculation,
     ) {
-        parent::__construct($user, $currency, $serverData, $panelData);
+        parent::__construct($user, $currency, $serverData, $panelData, $siteUrl);
     }
 
     public function getProduct(): ProductInterface

--- a/src/Core/DTO/Email/RenewalEmailContextDTO.php
+++ b/src/Core/DTO/Email/RenewalEmailContextDTO.php
@@ -12,10 +12,11 @@ readonly class RenewalEmailContextDTO extends EmailContextDTO
         string $currency,
         array $serverData,
         array $panelData,
+        string $siteUrl,
         private ProductInterface $product,
         private PriceCalculationDTO $priceCalculation,
     ) {
-        parent::__construct($user, $currency, $serverData, $panelData);
+        parent::__construct($user, $currency, $serverData, $panelData, $siteUrl);
     }
 
     public function getProduct(): ProductInterface

--- a/src/Core/Resources/translations/messages.cn.yaml
+++ b/src/Core/Resources/translations/messages.cn.yaml
@@ -1379,7 +1379,7 @@ pteroca:
       panel_password: '密码'
       panel_password_hint: '密码与您在客户面板的账户相同。'
       management_panel_hint: '要获取 FTP 访问信息，请登录管理面板。'
-      access_panel: '访问服务器面板'
+      access_panel: '访问客户端面板'
     renew:
       subject: '服务器续订'
       title: '服务器续费成功'
@@ -1406,7 +1406,6 @@ pteroca:
       suspension_date_label: '暂停日期'
       auto_delete_title: '自动删除警告'
       auto_delete_warning: '重要提示：如果未续费，您的服务器将在 %days% 天后（%deleteDate%）自动删除。'
-      panel_access: '访问面板'
 
   verification:
     title: '需要电子邮件验证'

--- a/src/Core/Resources/translations/messages.de.yaml
+++ b/src/Core/Resources/translations/messages.de.yaml
@@ -1365,7 +1365,7 @@ pteroca:
       panel_password: 'Passwort'
       panel_password_hint: 'Das Passwort ist dasselbe wie für Ihr Konto im Kundenbereich.'
       management_panel_hint: 'Um FTP-Daten zu erhalten, melden Sie sich im Verwaltungspanel an.'
-      access_panel: 'Server-Panel aufrufen'
+      access_panel: 'Client-Panel aufrufen'
     renew:
       subject: 'Serververlängerung'
       title: 'Server erfolgreich verlängert'
@@ -1392,7 +1392,6 @@ pteroca:
       suspension_date_label: 'Sperrdatum'
       auto_delete_title: 'Automatische Löschung Warnung'
       auto_delete_warning: 'Wichtig: Ihr Server wird automatisch nach %days% Tagen (%deleteDate%) gelöscht, falls nicht verlängert.'
-      panel_access: 'Zugang zum Panel'
 
   verification:
     title: 'E-Mail-Verifizierung erforderlich'

--- a/src/Core/Resources/translations/messages.de_CH.yaml
+++ b/src/Core/Resources/translations/messages.de_CH.yaml
@@ -1359,7 +1359,7 @@ pteroca:
       panel_password: 'Panel Passwort'
       panel_password_hint: 'Das Passwort ist das gleiche wie das Passwort für das Client-Panel-Konto.'
       management_panel_hint: 'Um FTP-Zugangsdaten zu erhalten, loggen Sie sich in das Server-Management-Panel ein.'
-      access_panel: 'Server-Panel aufrufen'
+      access_panel: 'Client-Panel aufrufen'
     renew:
       subject: 'Servererneuerung'
       title: 'Server erfolgreich verlängert'
@@ -1386,7 +1386,6 @@ pteroca:
       suspension_date_label: 'Sperrdatum'
       auto_delete_title: 'Automatische Löschung Warnung'
       auto_delete_warning: 'Wichtig: Ihr Server wird automatisch nach %days% Tagen (%deleteDate%) gelöscht, falls nicht erneuert.'
-      panel_access: 'Zugang zum Panel'
   verification:
     title: 'E-Mail-Verifizierung erforderlich'
     subtitle: 'Bitte verifizieren Sie Ihre E-Mail-Adresse, um fortzufahren'

--- a/src/Core/Resources/translations/messages.en.yaml
+++ b/src/Core/Resources/translations/messages.en.yaml
@@ -1351,7 +1351,7 @@ pteroca:
       panel_password: 'Panel password'
       panel_password_hint: 'The password is the same as your client panel account password.'
       management_panel_hint: 'To obtain FTP credentials, log in to the server management panel.'
-      access_panel: 'Access Server Panel'
+      access_panel: 'Access Client Panel'
     renew:
       subject: 'Server Renewal'
       title: 'Server Renewed Successfully'
@@ -1378,7 +1378,6 @@ pteroca:
       suspension_date_label: 'Suspension Date'
       auto_delete_title: 'Auto-Deletion Warning'
       auto_delete_warning: 'Important: Your server will be automatically deleted after %days% days (%deleteDate%) if not renewed.'
-      panel_access: 'Access Panel'
 
   verification:
     title: 'Email Verification Required'

--- a/src/Core/Resources/translations/messages.es.yaml
+++ b/src/Core/Resources/translations/messages.es.yaml
@@ -1365,7 +1365,7 @@ pteroca:
       panel_password: 'Contraseña'
       panel_password_hint: 'La contraseña es la misma que para tu cuenta en el panel de cliente.'
       management_panel_hint: 'Para obtener los datos FTP, inicia sesión en el panel de gestión.'
-      access_panel: 'Acceder al panel del servidor'
+      access_panel: 'Acceder al panel del cliente'
     renew:
       subject: 'Renovación del servidor'
       title: 'Servidor renovado exitosamente'
@@ -1392,7 +1392,6 @@ pteroca:
       suspension_date_label: 'Fecha de suspensión'
       auto_delete_title: 'Advertencia de eliminación automática'
       auto_delete_warning: 'Importante: Tu servidor será eliminado automáticamente después de %days% días (%deleteDate%) si no se renueva.'
-      panel_access: 'Acceso al panel'
 
   verification:
     title: 'Verificación de correo electrónico requerida'

--- a/src/Core/Resources/translations/messages.fr.yaml
+++ b/src/Core/Resources/translations/messages.fr.yaml
@@ -1364,7 +1364,7 @@ pteroca:
       panel_password: 'Mot de passe'
       panel_password_hint: 'Le mot de passe est identique à celui de votre compte client.'
       management_panel_hint: 'Pour obtenir les informations FTP, connectez-vous au panneau de gestion.'
-      access_panel: 'Accéder au panneau du serveur'
+      access_panel: 'Accéder au panneau client'
     renew:
       subject: 'Renouvellement du serveur'
       title: 'Serveur renouvelé avec succès'
@@ -1391,7 +1391,6 @@ pteroca:
       suspension_date_label: 'Date de suspension'
       auto_delete_title: 'Avertissement de suppression automatique'
       auto_delete_warning: 'Important : Votre serveur sera automatiquement supprimé après %days% jours (%deleteDate%) s''il n''est pas renouvelé.'
-      panel_access: 'Accès au panneau'
 
   verification:
     title: 'Vérification d''e-mail requise'

--- a/src/Core/Resources/translations/messages.hi.yaml
+++ b/src/Core/Resources/translations/messages.hi.yaml
@@ -1365,7 +1365,7 @@ pteroca:
       panel_password: 'पैनल पासवर्ड'
       panel_password_hint: 'पासवर्ड वही है जो आपके ग्राहक पैनल खाते का पासवर्ड है।'
       management_panel_hint: 'FTP क्रेडेंशियल प्राप्त करने के लिए, सर्वर प्रबंधन पैनल में लॉग इन करें।'
-      access_panel: 'सर्वर पैनल तक पहुंचें'
+      access_panel: 'क्लाइंट पैनल तक पहुंचें'
     renew:
       subject: 'सर्वर नवीनीकरण'
       title: 'सर्वर सफलतापूर्वक नवीनीकृत'
@@ -1392,7 +1392,6 @@ pteroca:
       suspension_date_label: 'निलंबन तिथि'
       auto_delete_title: 'स्वत: हटाने की चेतावनी'
       auto_delete_warning: 'महत्वपूर्ण: यदि नवीनीकृत नहीं किया गया तो आपका सर्वर %days% दिनों के बाद (%deleteDate%) स्वचालित रूप से हटा दिया जाएगा।'
-      panel_access: 'पैनल पहुंच'
 
   verification:
     title: 'ईमेल सत्यापन आवश्यक'

--- a/src/Core/Resources/translations/messages.id.yaml
+++ b/src/Core/Resources/translations/messages.id.yaml
@@ -1348,7 +1348,7 @@ pteroca:
       subject: 'Pembelian Server'
       title: 'Server Berhasil Dibeli'
       subtitle: 'Server Anda siap digunakan'
-      access_panel: 'Akses ke panel server'
+      access_panel: 'Akses ke panel klien'
       server_purchased: 'Anda telah membeli server dari toko kami.'
       expiration_date: 'Tanggal kedaluwarsa'
       product_details: 'Detail produk'
@@ -1387,7 +1387,6 @@ pteroca:
       server_name: 'Server: %serverName%'
       suspension_date: 'Ditangguhkan pada: %suspensionDate%'
       auto_delete_warning: 'Penting: Server Anda akan dihapus secara otomatis setelah %days% hari (%deleteDate%) jika tidak diperpanjang.'
-      panel_access: 'Akses Panel'
 
   verification:
     title: 'Verifikasi Email Diperlukan'

--- a/src/Core/Resources/translations/messages.it.yaml
+++ b/src/Core/Resources/translations/messages.it.yaml
@@ -1365,7 +1365,7 @@ pteroca:
       panel_password: 'Password'
       panel_password_hint: 'La password è la stessa del tuo account nel pannello clienti.'
       management_panel_hint: 'Per ottenere i dati FTP, accedi al pannello di gestione.'
-      access_panel: 'Accedi al pannello del server'
+      access_panel: 'Accedi al pannello client'
     renew:
       subject: 'Rinnovo server'
       title: 'Server rinnovato con successo'
@@ -1392,7 +1392,6 @@ pteroca:
       suspension_date_label: 'Data di sospensione'
       auto_delete_title: 'Avviso di eliminazione automatica'
       auto_delete_warning: 'Importante: Il tuo server verrà eliminato automaticamente dopo %days% giorni (%deleteDate%) se non rinnovato.'
-      panel_access: 'Accesso al pannello'
 
   verification:
     title: 'Verifica e-mail richiesta'

--- a/src/Core/Resources/translations/messages.nl.yaml
+++ b/src/Core/Resources/translations/messages.nl.yaml
@@ -1351,7 +1351,7 @@ pteroca:
       panel_password: 'Paneel wachtwoord'
       panel_password_hint: 'Het wachtwoord is hetzelfde als het wachtwoord van uw client panel account.'
       management_panel_hint: 'Log in op het server beheerpaneel om FTP gegevens te verkrijgen.'
-      access_panel: 'Toegang tot serverpaneel'
+      access_panel: 'Toegang tot clientpaneel'
     renew:
       subject: 'Server verlenging'
       title: 'Server succesvol verlengd'
@@ -1378,7 +1378,6 @@ pteroca:
       suspension_date_label: 'Opschortingsdatum'
       auto_delete_title: 'Automatische verwijderingswaarschuwing'
       auto_delete_warning: 'Belangrijk: Uw server wordt automatisch verwijderd na %days% dagen (%deleteDate%) als deze niet wordt verlengd.'
-      panel_access: 'Toegang tot paneel'
   verification:
     title: 'E-mail verificatie vereist'
     subtitle: 'Verificeer uw e-mailadres om door te gaan'

--- a/src/Core/Resources/translations/messages.pl.yaml
+++ b/src/Core/Resources/translations/messages.pl.yaml
@@ -1365,7 +1365,7 @@ pteroca:
       panel_password: 'Hasło'
       panel_password_hint: 'Hasło jest takie samo jak do Twojego konta w panelu klienta.'
       management_panel_hint: 'Aby uzyskać dane do FTP zaloguj się do panelu zarządzania serwerem.'
-      access_panel: 'Dostęp do panelu serwera'
+      access_panel: 'Dostęp do panelu klienta'
     renew:
       subject: 'Przedłużenie serwera'
       title: 'Serwer pomyślnie odnowiony'
@@ -1392,7 +1392,6 @@ pteroca:
       suspension_date_label: 'Data zawieszenia'
       auto_delete_title: 'Ostrzeżenie o automatycznym usunięciu'
       auto_delete_warning: 'Ważne: Twój serwer zostanie automatycznie usunięty po %days% dniach (%deleteDate%), jeśli nie zostanie przedłużony.'
-      panel_access: 'Dostęp do panelu'
 
   verification:
     title: 'Weryfikacja e-mail wymagana'

--- a/src/Core/Resources/translations/messages.pt.yaml
+++ b/src/Core/Resources/translations/messages.pt.yaml
@@ -1367,7 +1367,7 @@ pteroca:
       panel_password: 'Senha'
       panel_password_hint: 'A senha é a mesma da sua conta no painel do cliente.'
       management_panel_hint: 'Para obter os dados de FTP, faça login no painel de gerenciamento.'
-      access_panel: 'Acessar painel do servidor'
+      access_panel: 'Acessar painel do cliente'
     renew:
       subject: 'Renovação de servidor'
       title: 'Servidor renovado com sucesso'
@@ -1394,7 +1394,6 @@ pteroca:
       suspension_date_label: 'Data de suspensão'
       auto_delete_title: 'Aviso de exclusão automática'
       auto_delete_warning: 'Importante: O seu servidor será automaticamente eliminado após %days% dias (%deleteDate%) se não for renovado.'
-      panel_access: 'Acesso ao painel'
 
   verification:
     title: 'Verificação de e-mail obrigatória'

--- a/src/Core/Resources/translations/messages.ru.yaml
+++ b/src/Core/Resources/translations/messages.ru.yaml
@@ -1356,7 +1356,7 @@ pteroca:
       subject: 'Покупка сервера'
       title: 'Сервер успешно куплен'
       subtitle: 'Ваш сервер готов к использованию'
-      access_panel: 'Доступ к панели сервера'
+      access_panel: 'Доступ к панели клиента'
       server_purchased: 'Вы приобрели сервер в нашем магазине.'
       expiration_date: 'Дата окончания'
       product_details: 'Детали товара'
@@ -1395,7 +1395,6 @@ pteroca:
       server_name: 'Сервер: %serverName%'
       suspension_date: 'Приостановлен: %suspensionDate%'
       auto_delete_warning: 'Важно: Ваш сервер будет автоматически удален через %days% дней (%deleteDate%), если не будет продлен.'
-      panel_access: 'Доступ к панели'
   verification:
     title: 'Требуется подтверждение электронной почты'
     subtitle: 'Подтвердите свой адрес электронной почты, чтобы продолжить'

--- a/src/Core/Resources/translations/messages.ua.yaml
+++ b/src/Core/Resources/translations/messages.ua.yaml
@@ -1362,7 +1362,7 @@ pteroca:
       subject: 'Покупка сервера'
       title: 'Сервер успішно куплено'
       subtitle: 'Ваш сервер готовий до використання'
-      access_panel: 'Доступ до панелі сервера'
+      access_panel: 'Доступ до панелі клієнта'
       server_purchased: 'Ви придбали сервер у нашому магазині.'
       expiration_date: 'Дата закінчення'
       product_details: 'Деталі продукту'
@@ -1401,7 +1401,6 @@ pteroca:
       server_name: 'Сервер: %serverName%'
       suspension_date: 'Призупинено: %suspensionDate%'
       auto_delete_warning: 'Важливо: Ваш сервер буде автоматично видалено через %days% днів (%deleteDate%), якщо не буде подовжено.'
-      panel_access: 'Доступ до панелі'
 
   verification:
     title: 'Потрібне підтвердження електронної пошти'

--- a/src/Core/Service/Email/EmailContextBuilderService.php
+++ b/src/Core/Service/Email/EmailContextBuilderService.php
@@ -49,6 +49,7 @@ readonly class EmailContextBuilderService
             currency: $baseContext->getCurrency(),
             serverData: $baseContext->getServerData(),
             panelData: $baseContext->getPanelData(),
+            siteUrl: $baseContext->getSiteUrl(),
             product: $product,
             priceCalculation: $priceCalculation,
         );
@@ -72,6 +73,7 @@ readonly class EmailContextBuilderService
             currency: $baseContext->getCurrency(),
             serverData: $baseContext->getServerData(),
             panelData: $baseContext->getPanelData(),
+            siteUrl: $baseContext->getSiteUrl(),
             product: $product,
             priceCalculation: $priceCalculation,
         );
@@ -95,6 +97,7 @@ readonly class EmailContextBuilderService
 
         $currency = $this->settingService->getSetting(SettingEnum::INTERNAL_CURRENCY_NAME->value);
         $panelUrl = $this->panelUrlResolver->resolve();
+        $siteUrl = (string) $this->settingService->getSetting(SettingEnum::SITE_URL->value);
 
         $serverData = [
             'ip' => $serverDetails->ip,
@@ -111,6 +114,7 @@ readonly class EmailContextBuilderService
             currency: $currency,
             serverData: $serverData,
             panelData: $panelData,
+            siteUrl: $siteUrl,
         );
     }
 

--- a/themes/default/email/purchased_product.html.twig
+++ b/themes/default/email/purchased_product.html.twig
@@ -48,7 +48,7 @@
     } %}
 
     {% include 'email/components/button.html.twig' with {
-        url: panel.url,
+        url: siteUrl,
         text: 'pteroca.email.store.access_panel'|trans
     } %}
 

--- a/themes/default/email/renew_product.html.twig
+++ b/themes/default/email/renew_product.html.twig
@@ -48,7 +48,7 @@
     } %}
 
     {% include 'email/components/button.html.twig' with {
-        url: panel.url,
+        url: siteUrl,
         text: 'pteroca.email.store.access_panel'|trans
     } %}
 

--- a/themes/default/email/server_suspended.html.twig
+++ b/themes/default/email/server_suspended.html.twig
@@ -39,7 +39,7 @@
     </p>
 
     {% include 'email/components/button.html.twig' with {
-        url: panelUrl,
-        text: 'pteroca.email.suspended.panel_access'|trans
+        url: siteUrl,
+        text: 'pteroca.email.store.access_panel'|trans
     } %}
 {% endblock %}


### PR DESCRIPTION
This pull request updates the buttons within the Server Suspended, Server Renewed and Server Purchased E-Mails. 

**Why?**
Currently, the "Access Panel"-buttons in the Server Suspended, Server Renewed and Server Purchased E-Mails redirect the user to the Pterodactyl Panel. But due to the fact that the server is mainly managed in PteroCA, I think the buttons should redirect to PteroCA instead of Pterodactyl (the users can still go to Pterodactyl through the PteroCA Panel).

**Changes**
* Added a new `siteUrl` property to `EmailContextDTO`, including a getter and inclusion in the `toArray()` method. `src/Core/DTO/Email/EmailContextDTO.php`)
* Updated constructors of `PurchaseEmailContextDTO` and `RenewalEmailContextDTO` to accept and pass the new `siteUrl` parameter. (`src/Core/DTO/Email/PurchaseEmailContextDTO.php`, `src/Core/DTO/Email/RenewalEmailContextDTO.php`)
* Changed the button-"url"-parameter in `server_suspended.html.twig`, `renew_product.html.twig`, `purchased_product.html.twig` to "siteUrl"
* Standardized the translation for "Access Panel" to "Access Client Panel" (or equivalent) across all supported languages in the `messages.*.yaml` files
* Changed the button-"text"-parameter in `server_suspended.html.twig` to use the standardized translation "pteroca.email.store.access_panel"
* Removed redundant "pteroca.email.suspended.panel_access" translation entries in all language files
