### PR TITLE
Add maintenance mode logic to NodeSelectionService

### DIFF
--- a/src/Core/Service/Pterodactyl/NodeSelectionService.php
+++ b/src/Core/Service/Pterodactyl/NodeSelectionService.php
@@ -34,6 +34,15 @@ readonly class NodeSelectionService
                 ->nodes()
                 ->getNode($nodeId);
 
+            // Skip nodes in maintenance mode
+            if ($node['maintenance_mode'] === true) {
+                $this->logger->info('Skipping node in maintenance mode', [
+                    'node_id' => $node['id'],
+                    'node_name' => $node['name'] ?? 'unknown',
+                ]);
+                continue;
+            }
+            
             $freeMemory = $node['memory'] - $node['allocated_resources']['memory'];
             $freeDisk = $node['disk'] - $node['allocated_resources']['disk'];
 
@@ -113,6 +122,11 @@ readonly class NodeSelectionService
             ->nodes()
             ->getNode($nodeId);
 
+        // Throw error if node in maintenance mode wasn't skipped
+        if ($node['maintenance_mode'] === true) {
+            throw new Exception('Selected node is currently in maintenance mode');
+        }
+        
         $freeMemory = $node['memory'] - $node['allocated_resources']['memory'];
         $freeDisk = $node['disk'] - $node['allocated_resources']['disk'];
 


### PR DESCRIPTION
This update adds proper handling for nodes that are in maintenance mode to prevent
them from being selected during allocation.

### What was happening
`getBestAllocationId()` could select nodes that were marked as `maintenance_mode = true`.
This caused the panel to attempt provisioning on unavailable nodes, resulting in
504 errors when calling `api/application/servers`.

### What was changed
- Added a check in `getBestAllocationId()` to skip nodes in maintenance mode and log the skip.
- Added a safety check in `getAllocationForNode()` to throw an exception if a node in
  maintenance mode somehow reaches this stage.

### Code added
```php
// Skip nodes in maintenance mode
if ($node['maintenance_mode'] === true) {
    $this->logger->info('Skipping node in maintenance mode', [
        'node_id' => $node['id'],
        'node_name' => $node['name'] ?? 'unknown',
    ]);
    continue;
}

// Throw error if node in maintenance mode wasn't skipped
 if ($node['maintenance_mode'] === true) {
    throw new Exception('Selected node is currently in maintenance mode');
}
```