### PR TITLE
Fix server back links in panel theme

### DIFF
--- a/src/Core/Tests/Integration/Controller/ServerControllerTest.php
+++ b/src/Core/Tests/Integration/Controller/ServerControllerTest.php
@@ -57,6 +57,14 @@ class ServerControllerTest extends BaseTestCase
         $this->assertSelectorTextContains('.alert.alert-info', 'You do not have any servers yet.');
     }
 
+    public function testServerDetailBackLinksUsePanelRoute(): void
+    {
+        $template = file_get_contents(dirname(__DIR__, 5) . '/themes/default/panel/server/server.html.twig');
+
+        $this->assertStringContainsString("path('panel', { routeName: 'servers' })", $template);
+        $this->assertStringNotContainsString("path('servers')", $template);
+    }
+
     private function createTestUser(string $email = 'testuser@example.com'): User
     {
         $user = new User();

--- a/themes/default/panel/server/server.html.twig
+++ b/themes/default/panel/server/server.html.twig
@@ -31,7 +31,7 @@
                             </div>
                             <h4 class="mb-1 fw-bold">{{ server.serverProduct.name }} #{{ server.pterodactylServerIdentifier }}</h4>
                             <div class="ms-auto">
-                                <a href="{{ path('servers') }}" class="btn btn-outline-secondary px-3">
+                                <a href="{{ path('panel', { routeName: 'servers' }) }}" class="btn btn-outline-secondary px-3">
                                     <i class="fas fa-arrow-left me-1"></i>{{ 'pteroca.server.back_to_servers'|trans }}
                                 </a>
                             </div>
@@ -63,7 +63,7 @@
                             {% endif %}
                         </div>
                         <div class="ms-auto d-flex gap-2 align-items-center">
-                            <a href="{{ path('servers') }}" class="btn btn-outline-secondary px-3">
+                            <a href="{{ path('panel', { routeName: 'servers' }) }}" class="btn btn-outline-secondary px-3">
                                 <i class="fas fa-arrow-left me-1"></i>{{ 'pteroca.server.back_to_servers'|trans }}
                             </a>
                             {% if is_manage_in_pterodactyl_button_enabled() %}


### PR DESCRIPTION
## Summary
- route server-detail Back to Servers links through the panel wrapper
- keep the links consistent with other panel theme navigation
- add a regression check for the server-detail template route helper

Closes #188

## Tests
- git diff --check
- rg -n "path\('servers'\)" themes/default/panel/server/server.html.twig || true
- rg -n "path\('panel', \{ routeName: 'servers' \}\)" themes/default/panel/server/server.html.twig src/Core/Tests/Integration/Controller/ServerControllerTest.php

Could not run PHPUnit locally because this environment does not have `php` installed (`zsh: command not found: php`).